### PR TITLE
feat: Support runtime configuration

### DIFF
--- a/src/components/page-container/data/api.js
+++ b/src/components/page-container/data/api.js
@@ -1,10 +1,10 @@
 import { camelCaseObject, getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 
-const courseHomeBaseUrl = `${getConfig().LMS_BASE_URL}/api/course_home/v1/course_metadata`;
+export const getCourseHomeBaseUrl = () => `${getConfig().LMS_BASE_URL}/api/course_home/v1/course_metadata`;
 
 export async function getCourseHomeCourseMetadata(courseId) {
-  const courseHomeMetadataUrl = `${courseHomeBaseUrl}/${courseId}`;
+  const courseHomeMetadataUrl = `${getCourseHomeBaseUrl()}/${courseId}`;
   const { data } = await getAuthenticatedHttpClient().get(courseHomeMetadataUrl);
   return camelCaseObject(data);
 }

--- a/src/components/page-container/data/api.test.js
+++ b/src/components/page-container/data/api.test.js
@@ -1,0 +1,24 @@
+import { Factory } from 'rosie'; // eslint-disable-line import/no-extraneous-dependencies
+import { camelCaseObject } from '@edx/frontend-platform';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import MockAdapter from 'axios-mock-adapter';
+import { initializeMockApp } from '../../../setupTest';
+import * as api from './api';
+import './__factories__/courseMetadata.factory';
+
+describe('api', () => {
+  beforeAll(async () => {
+    await initializeMockApp();
+  });
+
+  test('getCourseHomeCourseMetadata', async () => {
+    const axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+    const courseMetadata = Factory.build('courseMetadata');
+    const { id: courseId } = courseMetadata;
+    axiosMock
+      .onGet(`${api.getCourseHomeBaseUrl()}/${courseId}`)
+      .reply(200, courseMetadata);
+    const data = await api.getCourseHomeCourseMetadata(courseId);
+    expect(data).toEqual(camelCaseObject(courseMetadata));
+  });
+});


### PR DESCRIPTION
frontend-platform supports runtime configuration since 2.5.0 (see the PR that introduced it[1], but it requires MFE cooperation.  This implements just that: by avoiding making configuration values constant, it should now be possible to change them after initialization.

Only a single change related to the `LMS_BASE_URL` setting was required.

[1] openedx/frontend-platform#335