### PR TITLE
fix: getting course-id when public path is set, closes #126

### DIFF
--- a/src/components/navigation-tabs/BackToInstructor.jsx
+++ b/src/components/navigation-tabs/BackToInstructor.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 
 import { getConfig } from '@edx/frontend-platform';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
@@ -6,11 +7,13 @@ import { Button, Icon } from '@edx/paragon';
 import { ArrowBack } from '@edx/paragon/icons';
 
 export default function BackToInstructor() {
+  const { courseId } = useParams();
+
   return (
     <Button
       variant="tertiary"
       className="mb-4.5 ml-n4.5 text-primary-500"
-      href={`${getConfig().LMS_BASE_URL}/courses/${window.location.pathname.split('/')[2]}/instructor#view-course-info`}
+      href={`${getConfig().LMS_BASE_URL}/courses/${courseId}/instructor#view-course-info`}
     >
       <Icon
         src={ArrowBack}


### PR DESCRIPTION
This fixes #126

  This change, change the way course-id is used, is navigation
  componenet, before it resolved by guessing course-id index
  in the url, which would not be true if the public path is
  set. Since public path would shift the index of course-id
  in the url when set.

  Instead the course-id is resolved through react-router just
  like the container componenet, using the `useParams` hook.
  
  ## Testing:
  
  If public path is not set, it shouldn't affect the behaviour, however if pubic path is set to anything, the back button would not work unless checking to this change