### PR TITLE
fix: Disable URL rewriting when creating links

### DIFF
--- a/src/components/bulk-email-tool/text-editor/TextEditor.jsx
+++ b/src/components/bulk-email-tool/text-editor/TextEditor.jsx
@@ -43,6 +43,8 @@ export default function TextEditor(props) {
         block_unsupported_drop: false,
         image_advtab: true,
         name: 'emailBody',
+        relative_urls: false,
+        remove_script_host: false,
       }}
       onEditorChange={onChange}
       value={value}


### PR DESCRIPTION
fixes https://github.com/openedx/wg-build-test-release/issues/294

The default behavior of the TinyMCE editor is to rewrite links that share the same domain as the component to be relative to that path. Relative URLs will never work in email contents, so they _always_ need to be absolute URLs. This adds the configuration settings for `relative_urls` and `remove_script_host` in TinyMCE to always be false, enabling it to always use absolute URLs. See
[here](https://www.tiny.cloud/docs/configure/url-handling/) for reference.

