### PR TITLE
fix: Added maxLength and default tip for email subject

### DIFF
--- a/src/components/bulk-email-tool/bulk-email-form/BulkEmailForm.jsx
+++ b/src/components/bulk-email-tool/bulk-email-form/BulkEmailForm.jsx
@@ -275,7 +275,10 @@ function BulkEmailForm(props) {
         />
         <Form.Group controlId="emailSubject">
           <Form.Label className="h3 text-primary-500">{intl.formatMessage(messages.bulkEmailSubjectLabel)}</Form.Label>
-          <Form.Control name="emailSubject" className="w-lg-50" onChange={onFormChange} value={editor.emailSubject} />
+          <Form.Control name="emailSubject" className="w-lg-50" onChange={onFormChange} value={editor.emailSubject} maxLength={128}/>
+          <Form.Control.Feedback className="px-3" type="default">
+              {intl.formatMessage(messages.bulkEmailFormSubjectTip)}
+          </Form.Control.Feedback>
           {!emailFormValidation.subject && (
             <Form.Control.Feedback className="px-3" hasIcon type="invalid">
               {intl.formatMessage(messages.bulkEmailFormSubjectError)}

--- a/src/components/bulk-email-tool/bulk-email-form/BulkEmailForm.jsx
+++ b/src/components/bulk-email-tool/bulk-email-form/BulkEmailForm.jsx
@@ -275,9 +275,9 @@ function BulkEmailForm(props) {
         />
         <Form.Group controlId="emailSubject">
           <Form.Label className="h3 text-primary-500">{intl.formatMessage(messages.bulkEmailSubjectLabel)}</Form.Label>
-          <Form.Control name="emailSubject" className="w-lg-50" onChange={onFormChange} value={editor.emailSubject} maxLength={128}/>
+          <Form.Control name="emailSubject" className="w-lg-50" onChange={onFormChange} value={editor.emailSubject} maxLength={128} />
           <Form.Control.Feedback className="px-3" type="default">
-              {intl.formatMessage(messages.bulkEmailFormSubjectTip)}
+            {intl.formatMessage(messages.bulkEmailFormSubjectTip)}
           </Form.Control.Feedback>
           {!emailFormValidation.subject && (
             <Form.Control.Feedback className="px-3" hasIcon type="invalid">

--- a/src/components/bulk-email-tool/bulk-email-form/messages.js
+++ b/src/components/bulk-email-tool/bulk-email-form/messages.js
@@ -41,6 +41,11 @@ const messages = defineMessages({
     defaultMessage: 'Subject',
     description: 'Email subject line input label. Meant to have colon or equivilant punctuation.',
   },
+  bulkEmailFormSubjectTip: {
+    id: 'bulk.email.form.subject.tip',
+    defaultMessage: '(Maximum 128 characters)',
+    description: 'Default Subject tip'
+  },
   bulkEmailFormSubjectError: {
     id: 'bulk.email.form.subject.error',
     defaultMessage: 'A subject is required',

--- a/src/components/bulk-email-tool/bulk-email-form/messages.js
+++ b/src/components/bulk-email-tool/bulk-email-form/messages.js
@@ -44,7 +44,7 @@ const messages = defineMessages({
   bulkEmailFormSubjectTip: {
     id: 'bulk.email.form.subject.tip',
     defaultMessage: '(Maximum 128 characters)',
-    description: 'Default Subject tip'
+    description: 'Default Subject tip',
   },
   bulkEmailFormSubjectError: {
     id: 'bulk.email.form.subject.error',


### PR DESCRIPTION
If the user puts more than 128 symbols in the email subject it causes an error.
![изображение](https://github.com/openedx/frontend-app-communications/assets/69678257/2bf4af9f-511b-4910-a9e0-302145349894)

Added length restriction and field tip.
Related PR: https://github.com/openedx/frontend-app-communications/pull/154
