### PR TITLE
fix: wrong id placement on the h1 tag

### DIFF
--- a/src/components/bulk-email-tool/BulkEmailTool.jsx
+++ b/src/components/bulk-email-tool/BulkEmailTool.jsx
@@ -24,7 +24,7 @@ export default function BulkEmailTool() {
             <Container size="md">
               <BackToInstructor courseId={courseId} />
               <div className="row pb-4.5">
-                <h1 className="text-primary-500" id="main-content">
+                <h1 className="text-primary-500">
                   <FormattedMessage
                     id="bulk.email.send.email.header"
                     defaultMessage="Send an email"

--- a/src/components/page-container/PageContainer.jsx
+++ b/src/components/page-container/PageContainer.jsx
@@ -67,7 +67,7 @@ export default function PageContainer(props) {
             courseTitle={courseMetadata.title}
           />
           <div className="pb-3 container">
-            <main>
+            <main id="main-content">
               {children}
             </main>
           </div>


### PR DESCRIPTION
There is a wrong `main-content` identificator placement, in the `src/components/page-container/PageContainer.jsx` component. For now, it's located at `h1` tag `<h1 className="text-primary-500" id="main-content">`.  As a shown on screen below, in other MFE this id allocated to the `<main>` tag, this fix going to make more consistent look with other applications and to prevent errors associated with this identificator.

<img width="1792" alt="Screenshot 2023-10-10 at 11 47 47" src="https://github.com/openedx/frontend-app-communications/assets/25877054/6da7105f-9a7c-4a24-a826-72e042a9deeb">
