### PR TITLE
chore: bump frontend-platform

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
         "@edx/frontend-component-footer": "12.2.0",
         "@edx/frontend-component-header": "4.6.0",
-        "@edx/frontend-platform": "5.0.0",
+        "@edx/frontend-platform": "5.5.2",
         "@edx/paragon": "^20.44.0",
         "@edx/tinymce-language-selector": "1.1.0",
         "@fortawesome/fontawesome-svg-core": "1.2.36",
@@ -3020,8 +3020,9 @@
       }
     },
     "node_modules/@edx/frontend-platform": {
-      "version": "5.0.0",
-      "license": "AGPL-3.0",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-5.5.2.tgz",
+      "integrity": "sha512-cbUvWcFL/mTc7eypBS/BnCojgWDcJCe3h3ffb3GD7F+Y4ysrFBJYf031qPcgmWNUrN30452dR7r1+sqE7uVvYA==",
       "dependencies": {
         "@cospired/i18n-iso-languages": "4.1.0",
         "@formatjs/intl-pluralrules": "4.3.3",
@@ -3049,7 +3050,7 @@
       },
       "peerDependencies": {
         "@edx/frontend-build": ">= 8.1.0 || ^12.9.0-alpha.1",
-        "@edx/paragon": ">= 10.0.0 < 21.0.0",
+        "@edx/paragon": ">= 10.0.0 < 22.0.0",
         "prop-types": "^15.7.2",
         "react": "^16.9.0 || ^17.0.0",
         "react-dom": "^16.9.0 || ^17.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
     "@edx/frontend-component-footer": "12.2.0",
     "@edx/frontend-component-header": "4.6.0",
-    "@edx/frontend-platform": "5.0.0",
+    "@edx/frontend-platform": "5.5.2",
     "@edx/paragon": "^20.44.0",
     "@edx/tinymce-language-selector": "1.1.0",
     "@fortawesome/fontawesome-svg-core": "1.2.36",


### PR DESCRIPTION
This PR resolves the `PUBLIC_PATH` configuration issue by upgrading frontend-platform from `v5.0.0` to `v5.5.2`.