### PR TITLE
feat!: remove broken transifex and use atlas exclusively | FC-0012

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,8 +1,0 @@
-[main]
-host = https://www.transifex.com
-
-[o:open-edx:p:edx-platform:r:frontend-app-communications]
-file_filter = src/i18n/messages/<lang>.json
-source_file = src/i18n/transifex_input.json
-source_lang = en
-type = KEYVALUEJSON

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,3 @@
-export TRANSIFEX_RESOURCE = frontend-app-communications
-transifex_langs = "ar,fr,es_419,zh_CN"
-
 intl_imports = ./node_modules/.bin/intl-imports.js
 transifex_utils = ./node_modules/.bin/transifex-utils.js
 i18n = ./src/i18n
@@ -32,35 +29,17 @@ detect_changed_source_translations:
 	# Checking for changed translations...
 	git diff --exit-code $(i18n)
 
-# Pushes translations to Transifex.  You must run make extract_translations first.
-push_translations:
-	# Pushing strings to Transifex...
-	tx push -s
-	# Fetching hashes from Transifex...
-	./node_modules/@edx/reactifex/bash_scripts/get_hashed_strings_v3.sh
-	# Writing out comments to file...
-	$(transifex_utils) $(transifex_temp) --comments --v3-scripts-path
-	# Pushing comments to Transifex...
-	./node_modules/@edx/reactifex/bash_scripts/put_comments_v3.sh
-
-ifeq ($(OPENEDX_ATLAS_PULL),)
-# Pulls translations from Transifex.
-pull_translations:
-	tx pull -t -f --mode reviewed --languages=$(transifex_langs)
-else
-# Experimental: OEP-58 Pulls translations using atlas
 pull_translations:
 	rm -rf src/i18n/messages
 	mkdir src/i18n/messages
 	cd src/i18n/messages \
-      && atlas pull --filter=$(transifex_langs) \
-               translations/frontend-component-header/src/i18n/messages:frontend-component-header  \
-               translations/frontend-component-footer/src/i18n/messages:frontend-component-footer \
-               translations/paragon/src/i18n/messages:paragon \
-               translations/frontend-app-communications/src/i18n/messages:frontend-app-communications
+	   && atlas pull \
+	            translations/frontend-component-header/src/i18n/messages:frontend-component-header  \
+	            translations/frontend-component-footer/src/i18n/messages:frontend-component-footer \
+	            translations/paragon/src/i18n/messages:paragon \
+	            translations/frontend-app-communications/src/i18n/messages:frontend-app-communications
 
 	$(intl_imports) frontend-component-header frontend-component-footer paragon frontend-app-communications
-endif
 
 # This target is used by Travis.
 validate-no-uncommitted-package-lock-changes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@edx/frontend-component-footer": "12.2.0",
         "@edx/frontend-component-header": "4.6.0",
         "@edx/frontend-platform": "5.5.2",
+        "@edx/openedx-atlas": "^0.5.0",
         "@edx/paragon": "^20.44.0",
         "@edx/tinymce-language-selector": "1.1.0",
         "@fortawesome/fontawesome-svg-core": "1.2.36",
@@ -3214,6 +3215,14 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@newrelic/publish-sourcemap": "^5.0.1"
+      }
+    },
+    "node_modules/@edx/openedx-atlas": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@edx/openedx-atlas/-/openedx-atlas-0.5.0.tgz",
+      "integrity": "sha512-wgcquAVj2BVw1rS7m1LZzUg6wVku37gs/Ks14LPWefpEIQ0HcTFV4nkg8dWfGX5dP3GiEp8s1Up7XwXzlErQhQ==",
+      "bin": {
+        "atlas": "atlas"
       }
     },
     "node_modules/@edx/paragon": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@edx/frontend-component-footer": "12.2.0",
     "@edx/frontend-component-header": "4.6.0",
     "@edx/frontend-platform": "5.5.2",
+    "@edx/openedx-atlas": "^0.5.0",
     "@edx/paragon": "^20.44.0",
     "@edx/tinymce-language-selector": "1.1.0",
     "@fortawesome/fontawesome-svg-core": "1.2.36",


### PR DESCRIPTION
Transifex integration never worked for the communication MFE. This pull request updates the MFE to use `atlas pull` exclusively.

## TODO

 - [x] Wait for #156 to be merged.
 - [x] Reflect changes on `master`
 - [x] ~Cherry-pick to `open-release/quince.master`~ no need to backport this clean up, because the Quince branch is ready for Tutor MFE.
 - [x] Test the updates

References
----------
This contribution is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).
