### PR TITLE
fix: date format depends on locale date format

### DIFF
--- a/src/components/bulk-email-tool/bulk-email-form/ScheduleEmailForm.jsx
+++ b/src/components/bulk-email-tool/bulk-email-form/ScheduleEmailForm.jsx
@@ -9,6 +9,7 @@ function ScheduleEmailForm(props) {
   const isMobile = useMobileResponsive();
   const { isValid, onDateTimeChange, dateTime } = props;
   const { date, time } = dateTime;
+  const descriptionDate = new Date('11/27/2023, 09:00 AM');
   return (
     <Form.Group>
       <div className={classNames('d-flex', isMobile ? 'flex-column' : 'flex-row', 'my-3')}>
@@ -30,7 +31,10 @@ function ScheduleEmailForm(props) {
           <small className="text-gray-500 x-small">
             <FormattedMessage
               id="bulk.email.form.schedule.date.description"
-              defaultMessage="Enter a start date, e.g. 11/27/2023"
+              defaultMessage="Enter a start date, e.g. {date}"
+              values={{
+                date: descriptionDate.toLocaleDateString(),
+              }}
             />
           </small>
         </div>
@@ -52,7 +56,10 @@ function ScheduleEmailForm(props) {
           <small className="text-gray-500 x-small">
             <FormattedMessage
               id="bulk.email.form.schedule.time.description"
-              defaultMessage="Enter a start time, e.g. 09:00 AM"
+              defaultMessage="Enter a start time, e.g. {time}"
+              values={{
+                time: descriptionDate.toLocaleTimeString([], { timeStyle: 'short' }),
+              }}
             />
           </small>
         </div>

--- a/src/components/bulk-email-tool/bulk-email-form/ScheduleEmailForm.jsx
+++ b/src/components/bulk-email-tool/bulk-email-form/ScheduleEmailForm.jsx
@@ -9,7 +9,8 @@ function ScheduleEmailForm(props) {
   const isMobile = useMobileResponsive();
   const { isValid, onDateTimeChange, dateTime } = props;
   const { date, time } = dateTime;
-  const descriptionDate = new Date('11/27/2023, 09:00 AM');
+  const descriptionDate = new Date();
+  descriptionDate.setDate(new Date().getDate() + 1);
   return (
     <Form.Group>
       <div className={classNames('d-flex', isMobile ? 'flex-column' : 'flex-row', 'my-3')}>

--- a/src/components/bulk-email-tool/bulk-email-task-manager/bulk-email-scheduled-emails-table/BulkEmailScheduledEmailsTable.jsx
+++ b/src/components/bulk-email-tool/bulk-email-task-manager/bulk-email-scheduled-emails-table/BulkEmailScheduledEmailsTable.jsx
@@ -26,6 +26,7 @@ function flattenScheduledEmailsArray(emails) {
     emailId: email.courseEmail.id,
     task: email.task,
     taskDue: new Date(email.taskDue).toLocaleString(),
+    taskDueUTC: email.taskDue,
     ...email.courseEmail,
     targets: email.courseEmail.targets.join(', '),
   }));
@@ -91,10 +92,10 @@ function BulkEmailScheduledEmailsTable({ intl }) {
   const handleEditEmail = (row) => {
     const {
       original: {
-        htmlMessage: emailBody, subject: emailSubject, taskDue, targets, schedulingId, emailId,
+        htmlMessage: emailBody, subject: emailSubject, taskDueUTC, targets, schedulingId, emailId,
       },
     } = row;
-    const dateTime = new Date(taskDue);
+    const dateTime = new Date(taskDueUTC);
     const emailRecipients = targets.replaceAll('-', ':').split(', ');
     const scheduleDate = formatDate(dateTime);
     const scheduleTime = formatTime(dateTime);


### PR DESCRIPTION
#### Description:
This pull request contains fix for correct date and time displaying depends on user locale date/time format.
In locations like `uk-UA` where the date format `DD.MM.YYYY` the date didn't set to the form on edit button click because of incorrect format for transforming it by `new Date()` constructor.
Current solution covers cases for different date formats in the form controls and text displaying of these dates.

|  en-US |  uk-UA |  en-GB  |
|---|---|---|
|  <img width="1017" alt="image" src="https://github.com/openedx/frontend-app-communications/assets/17108583/535d3e6b-702a-4b38-a5b0-3a1c2c2a874c"> |  <img width="1012" alt="image" src="https://github.com/openedx/frontend-app-communications/assets/17108583/2b0bec28-3425-4200-9f79-53c3961f6deb"> |  <img width="1007" alt="image" src="https://github.com/openedx/frontend-app-communications/assets/17108583/4f95115b-dc40-4b27-9bb7-df651f5dbe13">  |

#### Related Pull Requests:
PR to the open-release/quince.master branch: https://github.com/openedx/frontend-app-communications/pull/174
PR to the master branch: https://github.com/openedx/frontend-app-communications/pull/175
