### PR TITLE
fix: Remove extra margin around body element

### DIFF
--- a/src/components/bulk-email-tool/text-editor/TextEditor.jsx
+++ b/src/components/bulk-email-tool/text-editor/TextEditor.jsx
@@ -18,7 +18,7 @@ import 'tinymce/plugins/codesample';
 import '@edx/tinymce-language-selector';
 
 import contentUiCss from 'tinymce/skins/ui/oxide/content.css';
-import contentCss from 'tinymce/skins/content/default/content.css';
+import contentCss from 'tinymce/skins/content/default/content.css?raw';
 
 export default function TextEditor(props) {
   const {

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -22,8 +22,13 @@ const webpack5esmInteropRule = {
   },
 };
 
+const rawAssetRule = {
+  resourceQuery: /raw/,
+  type: 'asset/source',
+};
+
 const otherRules = config.module.rules;
 
-config.module.rules = [webpack5esmInteropRule, ...otherRules];
+config.module.rules = [rawAssetRule, webpack5esmInteropRule, ...otherRules];
 
 module.exports = config;

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -14,8 +14,13 @@ const webpack5esmInteropRule = {
   },
 };
 
+const rawAssetRule = {
+  resourceQuery: /raw/,
+  type: 'asset/source',
+};
+
 const otherRules = config.module.rules;
 
-config.module.rules = [webpack5esmInteropRule, ...otherRules];
+config.module.rules = [rawAssetRule, webpack5esmInteropRule, ...otherRules];
 
 module.exports = config;


### PR DESCRIPTION
This pull request proposes fixing the margin around the body element. This margin comes from the tinyMCE styles. In cases where we don't have a custom theme, and the header and footer are white, it's not noticeable (1st screenshot). However, if the header and footer have any color, it immediately stands out (2nd and 3rd screenshots). The `important` property is set not by chance, as without it, the styles from the tinyMCE override the styles from the index.scss file.

![Снимок экрана 2024-02-19 в 17 02 09](https://github.com/openedx/frontend-app-communications/assets/19806032/77719827-a190-4aec-b7ba-c472b1d36fe0)
![Снимок экрана 2024-02-15 в 11 37 22](https://github.com/openedx/frontend-app-communications/assets/19806032/f9cbe642-607b-4e83-a09c-c5053cd7b217)
![Снимок экрана 2024-02-15 в 11 38 08](https://github.com/openedx/frontend-app-communications/assets/19806032/ce6de5b7-5a50-4e07-9129-2c7c6088c291)