### PR TITLE
fix: Remove extra margin around body element (backport form master)

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -5,3 +5,7 @@
 
 @import "~@edx/frontend-component-header/dist/index";
 @import "~@edx/frontend-component-footer/dist/footer";
+
+body {
+    margin: 0 !important;
+}


### PR DESCRIPTION
This is backport from master - https://github.com/openedx/frontend-app-communications/pull/193

This pull request proposes fixing the margin around the body element. This margin comes from the tinyMCE styles. In cases where we don't have a custom theme, and the header and footer are white, it's not noticeable (1st screenshot). However, if the header and footer have any color, it immediately stands out (2nd and 3rd screenshots). The `important` property is set not by chance, as without it, the styles from the tinyMCE override the styles from the index.scss file.

![Снимок экрана 2024-02-19 в 17 02 09](https://github.com/openedx/frontend-app-communications/assets/19806032/77719827-a190-4aec-b7ba-c472b1d36fe0)
![Снимок экрана 2024-02-15 в 11 37 22](https://github.com/openedx/frontend-app-communications/assets/19806032/f9cbe642-607b-4e83-a09c-c5053cd7b217)
![Снимок экрана 2024-02-15 в 11 38 08](https://github.com/openedx/frontend-app-communications/assets/19806032/ce6de5b7-5a50-4e07-9129-2c7c6088c291)