### PR TITLE
fix: converted UTC time to local time in all the bulk email history tables

### DIFF
--- a/src/components/bulk-email-tool/bulk-email-task-manager/BulkEmailContentHistory.jsx
+++ b/src/components/bulk-email-tool/bulk-email-task-manager/BulkEmailContentHistory.jsx
@@ -52,21 +52,13 @@ function BulkEmailContentHistory({ intl }) {
    * display bug in the table.
    */
   function transformDataForTable() {
-    let tableData = [];
-    if (emailHistoryData) {
-      tableData = emailHistoryData.map((item) => {
-        const [, day, year, time] = item.created.match(/(\d+), (\d+) at (.+) UTC/);
-        const utcDateTimeString = `${year}-02-${day}T${time}Z`;
-        const localDateTime = new Date(utcDateTimeString).toLocaleString();
-        return {
-          ...item,
-          subject: item.email.subject,
-          sent_to: item.sent_to.join(', '),
-          created: localDateTime,
-        };
-      });
-    }
-    return tableData;
+    const tableData = emailHistoryData?.map((item) => ({
+      ...item,
+      subject: item.email.subject,
+      sent_to: item.sent_to.join(', '),
+      created: new Date(item.created).toLocaleString(),
+    }));
+    return tableData || [];
   }
 
   /**

--- a/src/components/bulk-email-tool/bulk-email-task-manager/BulkEmailContentHistory.jsx
+++ b/src/components/bulk-email-tool/bulk-email-task-manager/BulkEmailContentHistory.jsx
@@ -54,11 +54,17 @@ function BulkEmailContentHistory({ intl }) {
   function transformDataForTable() {
     let tableData = [];
     if (emailHistoryData) {
-      tableData = emailHistoryData.map((item) => ({
-        ...item,
-        subject: item.email.subject,
-        sent_to: item.sent_to.join(', '),
-      }));
+      tableData = emailHistoryData.map((item) => {
+        const [, day, year, time] = item.created.match(/(\d+), (\d+) at (.+) UTC/);
+        const utcDateTimeString = `${year}-02-${day}T${time}Z`;
+        const localDateTime = new Date(utcDateTimeString).toLocaleString();
+        return {
+          ...item,
+          subject: item.email.subject,
+          sent_to: item.sent_to.join(', '),
+          created: localDateTime,
+        };
+      });
     }
     return tableData;
   }

--- a/src/components/bulk-email-tool/bulk-email-task-manager/BulkEmailContentHistory.jsx
+++ b/src/components/bulk-email-tool/bulk-email-task-manager/BulkEmailContentHistory.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-unstable-nested-components */
 
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useParams } from 'react-router-dom';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
@@ -51,7 +51,7 @@ function BulkEmailContentHistory({ intl }) {
    * up a level (the `subject` field). We also convert the `sent_to` data to be a String rather than an array to fix a
    * display bug in the table.
    */
-  function transformDataForTable() {
+  const transformDataForTable = useMemo(() => {
     const tableData = emailHistoryData?.map((item) => ({
       ...item,
       subject: item.email.subject,
@@ -59,7 +59,7 @@ function BulkEmailContentHistory({ intl }) {
       created: new Date(item.created).toLocaleString(),
     }));
     return tableData || [];
-  }
+  }, [emailHistoryData]);
 
   /**
    * This function is responsible for setting the current `messageContent` state data. This will be the contents of a
@@ -100,7 +100,7 @@ function BulkEmailContentHistory({ intl }) {
    * contents of a previously sent message.
    */
   const additionalColumns = () => {
-    const tableData = transformDataForTable();
+    const tableData = transformDataForTable;
 
     return [
       {
@@ -137,7 +137,7 @@ function BulkEmailContentHistory({ intl }) {
           {showHistoricalEmailContentTable ? (
             <BulkEmailTaskManagerTable
               errorRetrievingData={errorRetrievingData}
-              tableData={transformDataForTable()}
+              tableData={transformDataForTable}
               tableDescription={intl.formatMessage(messages.emailHistoryTableViewMessageInstructions)}
               alertWarningMessage={intl.formatMessage(messages.noEmailData)}
               alertErrorMessage={intl.formatMessage(messages.errorFetchingEmailHistoryData)}

--- a/src/components/bulk-email-tool/bulk-email-task-manager/BulkEmailTaskHistory.jsx
+++ b/src/components/bulk-email-tool/bulk-email-task-manager/BulkEmailTaskHistory.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 
@@ -41,13 +41,13 @@ function BulkEmailTaskHistory({ intl }) {
     setShowHistoricalTaskContentTable(true);
   }
 
-  function transformDataForTable() {
+  const transformDataForTable = useMemo(() => {
     const tableData = emailTaskHistoryData?.map((item) => ({
       ...item,
       created: new Date(item.created).toLocaleString(),
     }));
     return tableData || [];
-  }
+  }, [emailTaskHistoryData]);
 
   const tableColumns = [
     {
@@ -103,7 +103,7 @@ function BulkEmailTaskHistory({ intl }) {
           {showHistoricalTaskContentTable ? (
             <BulkEmailTaskManagerTable
               errorRetrievingData={errorRetrievingData}
-              tableData={transformDataForTable()}
+              tableData={transformDataForTable}
               alertWarningMessage={intl.formatMessage(messages.noTaskHistoryData)}
               alertErrorMessage={intl.formatMessage(messages.errorFetchingTaskHistoryData)}
               columns={tableColumns}

--- a/src/components/bulk-email-tool/bulk-email-task-manager/BulkEmailTaskHistory.jsx
+++ b/src/components/bulk-email-tool/bulk-email-task-manager/BulkEmailTaskHistory.jsx
@@ -41,6 +41,17 @@ function BulkEmailTaskHistory({ intl }) {
     setShowHistoricalTaskContentTable(true);
   }
 
+  function transformDataForTable() {
+    let tableData = [];
+    if (emailTaskHistoryData) {
+      tableData = emailTaskHistoryData.map((item) => ({
+        ...item,
+        created: new Date(item.created).toLocaleString(),
+      }));
+    }
+    return tableData;
+  }
+
   const tableColumns = [
     {
       Header: `${intl.formatMessage(messages.taskHistoryTableColumnHeaderTaskType)}`,
@@ -95,7 +106,7 @@ function BulkEmailTaskHistory({ intl }) {
           {showHistoricalTaskContentTable ? (
             <BulkEmailTaskManagerTable
               errorRetrievingData={errorRetrievingData}
-              tableData={emailTaskHistoryData}
+              tableData={transformDataForTable()}
               alertWarningMessage={intl.formatMessage(messages.noTaskHistoryData)}
               alertErrorMessage={intl.formatMessage(messages.errorFetchingTaskHistoryData)}
               columns={tableColumns}

--- a/src/components/bulk-email-tool/bulk-email-task-manager/BulkEmailTaskHistory.jsx
+++ b/src/components/bulk-email-tool/bulk-email-task-manager/BulkEmailTaskHistory.jsx
@@ -42,14 +42,11 @@ function BulkEmailTaskHistory({ intl }) {
   }
 
   function transformDataForTable() {
-    let tableData = [];
-    if (emailTaskHistoryData) {
-      tableData = emailTaskHistoryData.map((item) => ({
-        ...item,
-        created: new Date(item.created).toLocaleString(),
-      }));
-    }
-    return tableData;
+    const tableData = emailTaskHistoryData?.map((item) => ({
+      ...item,
+      created: new Date(item.created).toLocaleString(),
+    }));
+    return tableData || [];
   }
 
   const tableColumns = [

--- a/src/components/bulk-email-tool/bulk-email-task-manager/test/BulkEmailContentHistory.test.jsx
+++ b/src/components/bulk-email-tool/bulk-email-task-manager/test/BulkEmailContentHistory.test.jsx
@@ -66,7 +66,8 @@ describe('BulkEmailContentHistory component', () => {
       // verify table contents
       const { emails } = emailHistoryData;
       const email = emails[0];
-      expect(await screen.findByText(email.created)).toBeTruthy();
+      const createdDate = new Date(email.created).toLocaleString();
+      expect(await screen.findByText(createdDate)).toBeTruthy();
       expect(await screen.findByText(email.number_sent)).toBeTruthy();
       expect(await screen.findByText(email.requester)).toBeTruthy();
       expect(await screen.findByText(email.sent_to.join(', '))).toBeTruthy();
@@ -103,7 +104,8 @@ describe('BulkEmailContentHistory component', () => {
       expect(await screen.findByText('Message:')).toBeTruthy();
       expect(await screen.findAllByText(email.email.subject)).toBeTruthy();
       expect(await screen.findAllByText(email.requester)).toBeTruthy();
-      expect(await screen.findAllByText(email.created)).toBeTruthy();
+      const createdDate = new Date(email.created).toLocaleString();
+      expect(await screen.findAllByText(createdDate)).toBeTruthy();
       expect(await screen.findAllByText(email.sent_to.join(', '))).toBeTruthy();
       // .replace() call strips the HTML tags from the string
       expect(await screen.findByText(email.email.html_message.replace(/<[^>]*>?/gm, ''))).toBeTruthy();

--- a/src/components/bulk-email-tool/bulk-email-task-manager/test/BulkEmailTaskHistory.test.jsx
+++ b/src/components/bulk-email-tool/bulk-email-task-manager/test/BulkEmailTaskHistory.test.jsx
@@ -55,7 +55,8 @@ describe('BulkEmailTaskHistory component', () => {
       // verification of row contents
       const { tasks } = taskHistoryData;
       const task = tasks[0];
-      expect(await screen.findByText(task.created)).toBeTruthy();
+      const createdDate = new Date(task.created).toLocaleString();
+      expect(await screen.findByText(createdDate)).toBeTruthy();
       expect(await screen.findByText(task.duration_sec)).toBeTruthy();
       expect(await screen.findByText(task.requester)).toBeTruthy();
       expect(await screen.findByText(task.status)).toBeTruthy();

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -29,6 +29,8 @@ Object.defineProperty(window, 'matchMedia', {
   })),
 });
 
+global.Date.prototype.toLocaleDateString = jest.fn();
+
 export function initializeMockApp() {
   mergeConfig({
     // MICROBA-1505: Remove this when we remove the flag from config


### PR DESCRIPTION
[INF-1229](https://2u-internal.atlassian.net/jira/software/c/projects/INF/boards/742?selectedIssue=INF-1229)

The value of created of each email item in the table data is updated from UTC to the user's local time. The tables updated are BulkEmailTaskHistory and BulkEmailContentHistory.

**Before:
<img width="760" alt="307777577-49975240-b672-4beb-a380-a6602e045b56" src="https://github.com/openedx/frontend-app-communications/assets/73840786/ee2fa4da-d906-4f88-a961-bb6e858914b7">

After:**
<img width="760" alt="after" src="https://github.com/openedx/frontend-app-communications/assets/73840786/58d8981e-4b9b-46cd-bc09-552e6d115d6d">
