### PR TITLE
Remove reference to deprecated frontend-lib-content-components repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,10 @@ pull_translations:
 	            translations/frontend-component-header/src/i18n/messages:frontend-component-header  \
 	            translations/frontend-component-footer/src/i18n/messages:frontend-component-footer \
 	            translations/paragon/src/i18n/messages:paragon \
-	            translations/frontend-lib-content-components/src/i18n/messages:frontend-lib-content-components \
 	            translations/frontend-platform/src/i18n/messages:frontend-platform \
 	            translations/frontend-app-communications/src/i18n/messages:frontend-app-communications
 
-	$(intl_imports) frontend-component-header frontend-component-footer paragon frontend-lib-content-components frontend-platform frontend-app-communications
+	$(intl_imports) frontend-component-header frontend-component-footer paragon frontend-platform frontend-app-communications
 
 # This target is used by Travis.
 validate-no-uncommitted-package-lock-changes:


### PR DESCRIPTION
In https://github.com/openedx/frontend-app-course-authoring/pull/1208 we merged `frontend-lib-content-components` into `frontend-app-course-authoring`, and there is no remaining usage of `frontend-lib-content-components` so we will soon be archiving that repo.

@OmarIthawi noticed that there is a reference to that deprecated `frontend-lib-content-components` repo in this project. It's unclear to me what it was supposed to be doing, so I'm just removing it for now. As far as I can tell, this app does not actually relate to `frontend-lib-content-components`, and there are no references to it in the code.