### PR TITLE
chore: remove husky 🪓🐶

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
         "@testing-library/react": "12.1.5",
         "axios-mock-adapter": "1.21.2",
         "glob": "7.2.3",
-        "husky": "7.0.4",
         "jest": "29.7.0",
         "prettier": "2.8.1",
         "rosie": "2.1.0"
@@ -11265,22 +11264,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
-      }
-    },
-    "node_modules/husky": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
-      "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "husky": "lib/bin.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/hyphenate-style-name": {

--- a/package.json
+++ b/package.json
@@ -19,11 +19,6 @@
     "dev": "PUBLIC_PATH=/communications/ MFE_CONFIG_API_URL='http://localhost:8000/api/mfe_config/v1' fedx-scripts webpack-dev-server --progress --host apps.local.openedx.io",
     "test": "TZ=UTC fedx-scripts jest --coverage --passWithNoTests"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "npm run lint"
-    }
-  },
   "author": "edX",
   "license": "AGPL-3.0",
   "homepage": "https://github.com/edx/frontend-app-communications#readme",
@@ -73,7 +68,6 @@
     "@testing-library/react": "12.1.5",
     "axios-mock-adapter": "1.21.2",
     "glob": "7.2.3",
-    "husky": "7.0.4",
     "jest": "29.7.0",
     "prettier": "2.8.1",
     "rosie": "2.1.0"


### PR DESCRIPTION
We remove husky, which is triggering pre-push git hooks, including running "npm lint". This is causing failures when building Docker images, because "npm clean-install --omit=dev" automatically triggers "npm prepare", which attemps to run "husky". But husky is not listed in the build dependencies, only in devDependencies. As a consequence, package installation is failing with the following error:

        14.13 > @edx/frontend-app-ora-grading@0.0.1 prepare
        14.13 > husky install
        14.13
        14.15 sh: 1: husky: not found

Similar to: https://github.com/openedx/frontend-app-learning/pull/1622