### PR TITLE
refactor: replacing injectIntl with useIntl part 1

### DIFF
--- a/src/components/bulk-email-tool/bulk-email-form/BulkEmailForm.jsx
+++ b/src/components/bulk-email-tool/bulk-email-form/BulkEmailForm.jsx
@@ -8,7 +8,7 @@ import {
 import {
   SpinnerSimple, Cancel, Send, Event, Check,
 } from '@openedx/paragon/icons';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import classNames from 'classnames';
 import { getConfig } from '@edx/frontend-platform';
 import TextEditor from '../text-editor/TextEditor';
@@ -51,8 +51,8 @@ function BulkEmailForm(props) {
     courseId,
     cohorts,
     courseModes,
-    intl,
   } = props;
+  const intl = useIntl();
   const [{ editor }, dispatch] = useContext(BulkEmailContext);
   const [emailFormStatus, setEmailFormStatus] = useState(FORM_SUBMIT_STATES.DEFAULT);
   const [emailFormValidation, setEmailFormValidation] = useState({
@@ -392,7 +392,7 @@ BulkEmailForm.defaultProps = {
 BulkEmailForm.propTypes = {
   courseId: PropTypes.string.isRequired,
   cohorts: PropTypes.arrayOf(PropTypes.string),
-  intl: intlShape.isRequired,
+
   courseModes: PropTypes.arrayOf(
     PropTypes.shape({
       slug: PropTypes.string.isRequired,
@@ -401,4 +401,4 @@ BulkEmailForm.propTypes = {
   ).isRequired,
 };
 
-export default injectIntl(BulkEmailForm);
+export default BulkEmailForm;

--- a/src/components/bulk-email-tool/bulk-email-task-manager/BulkEmailContentHistory.jsx
+++ b/src/components/bulk-email-tool/bulk-email-task-manager/BulkEmailContentHistory.jsx
@@ -3,7 +3,7 @@
 import React, { useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useParams } from 'react-router-dom';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 
 import {
   Button, Collapsible, Icon,
@@ -14,7 +14,8 @@ import { getSentEmailHistory } from './data/api';
 import BulkEmailTaskManagerTable from './BulkEmailHistoryTable';
 import ViewEmailModal from './ViewEmailModal';
 
-function BulkEmailContentHistory({ intl }) {
+function BulkEmailContentHistory() {
+  const intl = useIntl();
   const { courseId } = useParams();
   const [emailHistoryData, setEmailHistoryData] = useState();
   const [errorRetrievingData, setErrorRetrievingData] = useState(false);
@@ -154,7 +155,6 @@ function BulkEmailContentHistory({ intl }) {
 }
 
 BulkEmailContentHistory.propTypes = {
-  intl: intlShape.isRequired,
   row: PropTypes.shape({
     index: PropTypes.number,
   }),
@@ -164,4 +164,4 @@ BulkEmailContentHistory.defaultProps = {
   row: {},
 };
 
-export default injectIntl(BulkEmailContentHistory);
+export default BulkEmailContentHistory;

--- a/src/components/bulk-email-tool/bulk-email-task-manager/BulkEmailPendingTasks.jsx
+++ b/src/components/bulk-email-tool/bulk-email-task-manager/BulkEmailPendingTasks.jsx
@@ -1,13 +1,14 @@
 import React, { useState } from 'react';
 import { useParams } from 'react-router-dom';
 
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import { getInstructorTasks } from './data/api';
 import messages from './messages';
 import useInterval from '../../../utils/useInterval';
 import BulkEmailTaskManagerTable from './BulkEmailHistoryTable';
 
-function BulkEmailPendingTasks({ intl }) {
+function BulkEmailPendingTasks() {
+  const intl = useIntl();
   const { courseId } = useParams();
 
   const [instructorTaskData, setInstructorTaskData] = useState();
@@ -89,8 +90,4 @@ function BulkEmailPendingTasks({ intl }) {
   );
 }
 
-BulkEmailPendingTasks.propTypes = {
-  intl: intlShape.isRequired,
-};
-
-export default injectIntl(BulkEmailPendingTasks);
+export default BulkEmailPendingTasks;

--- a/src/components/bulk-email-tool/bulk-email-task-manager/BulkEmailTaskHistory.jsx
+++ b/src/components/bulk-email-tool/bulk-email-task-manager/BulkEmailTaskHistory.jsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 
 import { Icon, Collapsible } from '@openedx/paragon';
 import { SpinnerSimple } from '@openedx/paragon/icons';
@@ -11,7 +11,8 @@ import BulkEmailTaskManagerTable from './BulkEmailHistoryTable';
 
 import './bulkEmailTaskHistory.scss';
 
-function BulkEmailTaskHistory({ intl }) {
+function BulkEmailTaskHistory() {
+  const intl = useIntl();
   const { courseId } = useParams();
 
   const [emailTaskHistoryData, setEmailTaskHistoryData] = useState([]);
@@ -117,8 +118,4 @@ function BulkEmailTaskHistory({ intl }) {
   );
 }
 
-BulkEmailTaskHistory.propTypes = {
-  intl: intlShape.isRequired,
-};
-
-export default injectIntl(BulkEmailTaskHistory);
+export default BulkEmailTaskHistory;


### PR DESCRIPTION
## Description

Closes https://github.com/openedx/frontend-app-communications/issues/243

Replacing the usage of `injectInt` HOC with `useIntl()` hook from `@edx/frontend-platform/i18n` and all related code.
Most of the refactor of the files was made using this codemon: https://github.com/WGU-Open-edX/oex-utils/tree/main/intl-modernizer.
