### PR TITLE
refactor: replacing injectIntl with useIntl part 2

### DIFF
--- a/src/components/bulk-email-tool/bulk-email-task-manager/BulkEmailTaskManager.jsx
+++ b/src/components/bulk-email-tool/bulk-email-task-manager/BulkEmailTaskManager.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import { getConfig } from '@edx/frontend-platform';
 import BulkEmailContentHistory from './BulkEmailContentHistory';
 import BulkEmailTaskHistory from './BulkEmailTaskHistory';
@@ -9,7 +9,8 @@ import messages from './messages';
 import BulkEmailScheduledEmailsTable from './bulk-email-scheduled-emails-table';
 import BulkEmailPendingTasksAlert from './BulkEmailPendingTasksAlert';
 
-function BulkEmailTaskManager({ intl, courseId }) {
+function BulkEmailTaskManager({ courseId }) {
+  const intl = useIntl();
   return (
     <div className="w-100">
       {getConfig().SCHEDULE_EMAIL_SECTION && (
@@ -34,8 +35,7 @@ function BulkEmailTaskManager({ intl, courseId }) {
 }
 
 BulkEmailTaskManager.propTypes = {
-  intl: intlShape.isRequired,
   courseId: PropTypes.string.isRequired,
 };
 
-export default injectIntl(BulkEmailTaskManager);
+export default BulkEmailTaskManager;

--- a/src/components/bulk-email-tool/bulk-email-task-manager/ViewEmailModal.jsx
+++ b/src/components/bulk-email-tool/bulk-email-task-manager/ViewEmailModal.jsx
@@ -1,14 +1,15 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { ActionRow, Button, ModalDialog } from '@openedx/paragon';
-import { FormattedMessage, injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 import messages from './messages';
 import { BulkEmailContext } from '../bulk-email-context';
 import { copyToEditor } from '../bulk-email-form/data/actions';
 
 function ViewEmailModal({
-  intl, messageContent, isOpen, setModalOpen,
+  messageContent, isOpen, setModalOpen,
 }) {
+  const intl = useIntl();
   const [, dispatch] = useContext(BulkEmailContext);
   return (
     <div>
@@ -72,7 +73,6 @@ function ViewEmailModal({
 }
 
 ViewEmailModal.propTypes = {
-  intl: intlShape.isRequired,
   messageContent: PropTypes.shape({
     subject: PropTypes.string,
     requester: PropTypes.string,
@@ -86,4 +86,4 @@ ViewEmailModal.propTypes = {
   setModalOpen: PropTypes.func.isRequired,
 };
 
-export default injectIntl(ViewEmailModal);
+export default ViewEmailModal;

--- a/src/components/bulk-email-tool/bulk-email-task-manager/bulk-email-scheduled-emails-table/BulkEmailScheduledEmailsTable.jsx
+++ b/src/components/bulk-email-tool/bulk-email-task-manager/bulk-email-scheduled-emails-table/BulkEmailScheduledEmailsTable.jsx
@@ -4,7 +4,7 @@
 import React, {
   useCallback, useContext, useState, useEffect,
 } from 'react';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import {
   Alert, DataTable, Icon, IconButton, useToggle,
 } from '@openedx/paragon';
@@ -32,7 +32,8 @@ function flattenScheduledEmailsArray(emails) {
   }));
 }
 
-function BulkEmailScheduledEmailsTable({ intl }) {
+function BulkEmailScheduledEmailsTable() {
+  const intl = useIntl();
   const { courseId } = useParams();
   const [{ scheduledEmailsTable }, dispatch] = useContext(BulkEmailContext);
   const [tableData, setTableData] = useState([]);
@@ -196,8 +197,4 @@ function BulkEmailScheduledEmailsTable({ intl }) {
   );
 }
 
-BulkEmailScheduledEmailsTable.propTypes = {
-  intl: intlShape.isRequired,
-};
-
-export default injectIntl(BulkEmailScheduledEmailsTable);
+export default BulkEmailScheduledEmailsTable;

--- a/src/components/bulk-email-tool/task-alert-modal/TaskAlertModal.jsx
+++ b/src/components/bulk-email-tool/task-alert-modal/TaskAlertModal.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { ActionRow, AlertModal, Button } from '@openedx/paragon';
-import { FormattedMessage, injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 
 function TaskAlertModal(props) {
   const {
-    isOpen, close, alertMessage, intl,
+    isOpen, close, alertMessage,
   } = props;
-
+  const intl = useIntl();
   const messages = {
     taskAlertTitle: {
       id: 'bulk.email.task.alert.title',
@@ -57,7 +57,6 @@ TaskAlertModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   close: PropTypes.func.isRequired,
   alertMessage: PropTypes.node.isRequired,
-  intl: intlShape.isRequired,
 };
 
-export default injectIntl(TaskAlertModal);
+export default TaskAlertModal;


### PR DESCRIPTION
## Description

Closes https://github.com/openedx/frontend-app-communications/issues/244

Replacing the usage of `injectInt` HOC with `useIntl()` hook from `@edx/frontend-platform/i18n` and all related code.
Most of the refactor of the files was made using this codemon: https://github.com/WGU-Open-edX/oex-utils/tree/main/intl-modernizer.
