### PR TITLE
build: Upgrade to Node 24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
       "devDependencies": {
         "@edx/browserslist-config": "^1.2.0",
         "@edx/reactifex": "^2.1.1",
+        "@edx/typescript-config": "^1.1.0",
         "@openedx/frontend-build": "^14.6.2",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.2.0",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "scripts": {
     "build": "fedx-scripts webpack",
     "i18n_extract": "fedx-scripts formatjs extract",
-    "lint": "fedx-scripts eslint --ext .js --ext .jsx .",
-    "lint:fix": "fedx-scripts eslint --fix --ext .js --ext .jsx .",
+    "lint": "fedx-scripts eslint --ext .js --ext .jsx src/",
+    "lint:fix": "fedx-scripts eslint --fix --ext .js --ext .jsx src/",
     "snapshot": "fedx-scripts jest --updateSnapshot",
     "start": "fedx-scripts webpack-dev-server --progress",
     "dev": "PUBLIC_PATH=/communications/ MFE_CONFIG_API_URL='http://localhost:8000/api/mfe_config/v1' fedx-scripts webpack-dev-server --progress --host apps.local.openedx.io",
@@ -62,6 +62,7 @@
   "devDependencies": {
     "@edx/browserslist-config": "^1.2.0",
     "@edx/reactifex": "^2.1.1",
+    "@edx/typescript-config": "^1.1.0",
     "@openedx/frontend-build": "^14.6.2",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",

--- a/src/components/bulk-email-tool/test/BulkEmailTool.test.jsx
+++ b/src/components/bulk-email-tool/test/BulkEmailTool.test.jsx
@@ -23,10 +23,6 @@ jest.mock('react-router-dom', () => ({
     courseId: 'test-course-id',
   })),
 }));
-jest.mock('@edx/frontend-component-header', () => ({
-  __esModule: true,
-  default: () => null,
-}));
 
 describe('BulkEmailTool', () => {
   beforeEach(() => jest.resetModules());

--- a/src/components/page-container/test/PageContainer.test.jsx
+++ b/src/components/page-container/test/PageContainer.test.jsx
@@ -23,10 +23,6 @@ jest.mock('react-router-dom', () => ({
     courseId: 'test-course-id',
   })),
 }));
-jest.mock('@edx/frontend-component-header', () => ({
-  __esModule: true,
-  default: () => null,
-}));
 
 describe('PageContainer', () => {
   beforeEach(() => jest.resetModules());

--- a/src/index.test.jsx
+++ b/src/index.test.jsx
@@ -3,7 +3,7 @@ import {
 } from '@edx/frontend-platform';
 
 // Jest needs this for module resolution
-import * as app from '.'; // eslint-disable-line no-unused-vars
+import * as app from '.'; // eslint-disable-line @typescript-eslint/no-unused-vars
 
 // These need to be var not let so they get hoisted
 // and can be used by jest.mock (which is also hoisted)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@edx/typescript-config",
+  "compilerOptions": {
+    "baseUrl": "./src",
+    "paths": {
+      "*": ["*"]
+    },
+    "rootDir": ".",
+    "outDir": "dist"
+  },
+  "include": ["*.js", ".eslintrc.js", "src/**/*", "plugins/**/*", "jest.config.ts"],
+  "exclude": ["*.js", ".eslintrc.js", "dist", "node_modules"]
+}


### PR DESCRIPTION
### Description

As a second step in the Node 24 upgrade process, upgrade `.nvmrc` and regenerate `package-lock.json` from scratch using Node 24. Also make the Node 24 test a blocking one.

See [the tracking issue](https://github.com/openedx/frontend-app-communications/issues/238) for further information.
